### PR TITLE
fix some compatibility issues with 16.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+* fixed some compatability issues with Ubuntu 16.04 (xenial). Some log
+  types don't exist or have different names with the version that gets
+  installed there.
 ### Removed
 
 ## [v1.0.0] - 2022-02-23

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,11 +1,22 @@
 ---
 - name: Converge
   hosts: all
+  gather_facts: true
   tasks:
     - name: Update APT
       apt:
         update_cache: yes
         cache_valid_time: 3600
+
+    - name: Install python libs
+      apt:
+        name: python3-setuptools
+        state: latest
+
+    - name: Install yamllint
+      apt:
+        name: yamllint
+        state: latest
     - name: "Include appsembler_ops_agent_config_role"
       include_role:
         name: "appsembler_ops_agent_config_role"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,12 +3,48 @@
 
 - name: Verify
   hosts: all
-  gather_facts: false
+  gather_facts: true
   tasks:
   - name: check that config file exists
     stat:
       path: /etc/google-cloud-ops-agent/config.yaml
     register: p
+
   - assert:
       that:
         - p.stat.exists
+
+  - name: make sure that the config is valid yaml
+    shell: "yamllint -d '{extends: relaxed, rules: {indentation: disable}}' /etc/google-cloud-ops-agent/config.yaml"
+
+  - name: get contents of config file
+    shell: cat /etc/google-cloud-ops-agent/config.yaml
+    register: config_contents
+
+  # this is handy to uncomment if you are running into yamllint problems:
+  # - debug:
+  #     msg: "{{ config_contents.stdout.split('\n') }}"
+
+  - name: xenial doesn't have postgresql_general
+    assert:
+      that:
+        config_contents.stdout.find('postgresql_general') == -1
+    when: ansible_distribution_release == 'xenial'
+
+  - name: non-xenial does have postgresql_general
+    assert:
+      that:
+        config_contents.stdout.find('postgresql_general') != -1
+    when: ansible_distribution_release != 'xenial'
+
+  - name: xenial doesn't have elasticsearch_json
+    assert:
+      that:
+        config_contents.stdout.find('elasticsearch_json') == -1
+    when: ansible_distribution_release == 'xenial'
+
+  - name: non-xenial does have elasticsearch_json
+    assert:
+      that:
+        config_contents.stdout.find('elasticsearch_json') != -1
+    when: ansible_distribution_release != 'xenial'

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -22,16 +22,22 @@ logging:
       type: files
       include_paths:
       - /edx/var/log/elasticsearch/*.log
+{% if ansible_distribution_release != "xenial" %}
     elasticsearch_json:
       type: elasticsearch_json
     elasticsearch_gc:
       type: elasticsearch_gc
+{% endif %}
     letsencrypt:
       type: files
       include_paths:
       - /var/log/letsencrypt/letsencrypt.log
     mongodb:
+{% if ansible_distribution_release == "xenial" %}
+      type: files
+{% else %}
       type: mongodb
+{% endif %}
       include_paths:
       - /var/log/mongodb/*.log
       - /edx/var/log/mongodb/*.log
@@ -54,8 +60,16 @@ logging:
       include_paths:
       - /var/log/nginx/error.log
       - /edx/var/log/nginx/error.log
-    postgresql_general:
+    postgresql:
+{% if ansible_distribution_release == "xenial" %}
+      type: files
+{% else %}
       type: postgresql_general
+{% endif %}
+{% if ansible_distribution_release == "xenial" %}
+      include_paths:
+      - /var/log/postgresql/*.log
+{% endif %}
     rabbitmq:
       type: files
       include_paths:
@@ -88,8 +102,10 @@ logging:
       elasticsearch:
         receivers:
           - elasticsearch
+{% if ansible_distribution_release != "xenial" %}
           - elasticsearch_json
           - elasticsearch_gc
+{% endif %}
       letsencrypt:
         receivers: [letsencrypt]
       mongodb:
@@ -103,7 +119,7 @@ logging:
       nginx:
         receivers: [nginx_access, nginx_error]
       postgresql:
-        receivers: [postgresql_general]
+        receivers: [postgresql]
       rabbitmq:
         receivers: [rabbitmq]
       redis:
@@ -115,11 +131,14 @@ metrics:
     hostmetrics:
       type: hostmetrics
       collection_interval: 60s
+{% if ansible_distribution_release != "xenial" %}
     memcached:
       type: memcached
+{% endif %}
     nginx:
       type: nginx
       stub_status_url: http://127.0.0.1:80/status
+      collection_interval: 60s
   processors:
     metrics_filter:
       type: exclude_metrics
@@ -129,9 +148,11 @@ metrics:
       default_pipeline:
         receivers: [hostmetrics]
         processors: [metrics_filter]
+{% if ansible_distribution_release != "xenial" %}
       memcached:
         receivers:
           - memcached
+{% endif %}
       nginx:
         receivers:
           - nginx


### PR DESCRIPTION
Google's installer puts a slightly different version of the ops agent on 16.04 systems and that version is missing some log types and has different names for a few others.

I anticipated some of this, which is why the config was already a Jinja2 template rather than a plain file.

So we conditionally tweak the generated config a bit depending on which Ubuntu release it's getting installed on.

That introduces some potential for breaking the config though, so I also added a `yamllint` check to the output and some basic tests that a few of the log types exist/don't exist as appropriate in the generated config.
